### PR TITLE
Proposta para modificar o uso de +1 para tag de Aprovado 1 e Aprovado 2

### DIFF
--- a/CONTRIBUICAO.md
+++ b/CONTRIBUICAO.md
@@ -21,8 +21,8 @@ Para contribuir com um projeto deve-se seguir os seguintes passos:
 1. Fazer um clone do projeto;
 2. Criar uma nova branch, com prefixo `feature/` e algo que sugira a proposta da contribuição;
 3. Quando finalizada a implementação, deverá ser feito um Pull Request para a branch `master` e adicionar uma tag `Revisão`;
-4. No mínimo 2 outros membros do time no projeto deverão revisar o código, comentários e funcionamento do recursos, isso poderá levar ao processo de revisão, caso aceito, ambos membros devem adicionar +1 como comentário do Pull Request;
-5. O ultimo engenheiro a revisar deverá adicionar a tag `Aceito` para o Pull Request e em seguida aplicar o Merge utilizando o botão na interface do Github;
+4. No mínimo 2 outros membros do time no projeto deverão revisar o código, comentários e funcionamento do recursos, isso poderá levar ao processo de revisão, caso aceito, ambos membros devem adicionar as tags `Aprovado 1` e o proximo `Aprovado 2` no Pull Request;
+5. Com duas aprovações de diferentes membros, o projeto está liberado para o Pull Request e em seguida aplicar o Merge utilizando o botão na interface do Github, feito pelo autor ou membro com permissão suficiente;
 6. A branch com a `feature` deve ser apagada, pois a mesma já está presente no branch `master`;
 
 **Atenção**: Nunca faça Merge para o branch `master` manualmente, ou faça commits diretamente no branch `master`, respeite o processo e a comunidade.


### PR DESCRIPTION
Estava analisando aqui como a nossa estrutura é pouco hierárquica e a gente precisa de pelo menos duas pessoas pra aprovar uma modificação, o comentário de +1 pode acabar sendo bagunçado, uma vez que comece haver revisões no projeto, não saberemos exatamente quando ele está bom pra dar merge.

Então eu sugiro que utilizemos 2 tag's, `Aprovado 1` e `Aprovado 2` cada uma deve ser adicionada ao PR por um membro diferente e assim saberemos que está pronta para o merge, caso precise de revisão a tag pode ser removida ou a segunda não ser adicionada até que se defina o proceder.

Se isso for aprovado, as tags deverão ser criadas aqui neste Repo, os PR pendentes e futuros precisarão passar pelo novo processo.

(pra aprovar este tem que ser pelo processo antigo de +1 no comentário hehe)
